### PR TITLE
Fix console for rpi5 1.1 boards

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -290,6 +290,7 @@ images:
           "%{XEN_DT_SCMI_NAME}.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{XEN_DT_SCMI_NAME}.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-domd-scmi.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-domd-scmi.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-pcie1-scmi.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-pcie1-scmi.dtbo"
+          "overlays/bcm2712d0.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/raspberrypi5/bcm2712d0.dtbo"
       dom0:
         gpt_type: ebd0a0a2-b9e5-4433-87c0-68b6b72699c7
         type: vfat


### PR DESCRIPTION
In the new revision of the RPi5 board, the hardware was changed, including the interrupt for the UART console, so the console did not work on the 1.1 rev of the board. Taking into consideration that the bootloader chooses device tree overlay files by itself, to fix it, needed to add required overlay file.

meta-raspberrypi commit which mentions about 1.1: `1467f18 (Moving bcm2712d0.dtbo into rpi-base.inc, 2025-04-17)`

@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym