### PR TITLE
yaml: Add missed targets for WIFI and CAN

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -374,6 +374,9 @@ parameters:
               conf:
                 - [MACHINE_FEATURES:append, " domd_wifi"]
                 - [LICENSE_FLAGS_ACCEPTED, "synaptics-killswitch"]
+              target_images:
+                - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-wifi.dtbo"
+                - "tmp/deploy/images/%{MACHINE}/wifi-passthrough.dtbo"
         images:
           full:
             partitions:
@@ -397,7 +400,7 @@ parameters:
                 - [MACHINE_FEATURES:append, " domd_can"]
                 - [DOMD_OVERLAYS:append, " %{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"]
               target_images:
-                - "tmp/deploy/images/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
+                - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
         images:
           full:
             partitions:
@@ -416,7 +419,7 @@ parameters:
                 - [MACHINE_FEATURES:append, " domd_can"]
                 - [DOMD_OVERLAYS:append, " %{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"]
               target_images:
-                - "tmp/deploy/images/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
+                - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
         images:
           full:
             partitions:


### PR DESCRIPTION
With the clean build, two separate issues are observed:

- ninja: error: 'yocto/build-domd/tmp/deploy/images/raspberrypi5/ bcm2712-raspberrypi5-can-mcp2515.dtbo', needed by 'full.img', missing and no known rule to make it

- ninja: error: 'yocto/build-domd/tmp/deploy/images/raspberrypi5/ bcm2712-raspberrypi5-wifi.dtbo', needed by 'full.img', missing and no known rule to make it

Therefore, added the missed dtbo files to the target images for parameter ENABLE_WIFI and fixed the paths to the dtbo files for ENABLE_CAN.

Fixes the issue https://github.com/xen-troops/meta-xt-prod-devel-rpi5/issues/69

@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym