### PR TITLE
rpi5.yaml: Release v0.4.0

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -42,7 +42,7 @@ common_data:
       rev: "727811eaf256b88fd135be99559f2cbf14c82fce"
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
-      rev: "3f17cfe7a64491ff854a34aa76a90b3235723bc1"
+      rev: "v0.3.0"
     - type: git
       url: "https://git.yoctoproject.org/meta-virtualization"
       rev: "9e040ee8dd6025558ea60ac9db60c41bfeddf221"
@@ -82,7 +82,7 @@ components:
     sources:
       - type: west
         url: "https://github.com/xen-troops/zephyr-dom0-xt.git"
-        rev: "rpi5_dom0_dev"
+        rev: "rpi5-v0.4.0"
     builder:
       type: zephyr
       board: "%{ZEPHYR_DOM0_MACHINE}"
@@ -148,7 +148,7 @@ components:
         rev: "48452445d779b0f69bf1ead12b3850d50eb8920d"
       - type: git
         url: "https://github.com/xen-troops/meta-xt-rpi5.git"
-        rev: "main"
+        rev: "v0.4.0"
     builder:
       type: yocto
       work_dir: "%{DOMD_BUILD_DIR}"


### PR DESCRIPTION
Stabilize source code for the release v0.4.0.

@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym